### PR TITLE
Add RotorHazard 4.5.0-beta.1 support

### DIFF
--- a/docs/update-notes.txt
+++ b/docs/update-notes.txt
@@ -5,6 +5,9 @@
         UPDATE NOTES:
         ^^^^^^^^^^^^
 
+6n4.440.36
+1. RotorHazard 4.5.0-beta.1 release installation and update support added.
+
 6n3.440.36
 1. Fixed Trixie installation config file logic
 

--- a/version.txt
+++ b/version.txt
@@ -1,6 +1,6 @@
-6n3.440.36
+6n4.440.36
 
-4.4.0-beta.3
+4.5.0-beta.1
 
 First line - version of this program - it has nothing to do with the RH version.
 Third line - name of the latest beta RH release.


### PR DESCRIPTION
## Summary

- update RHIM version to 6n4.440.36
- set the supported RotorHazard beta release to 4.5.0-beta.1
- add the corresponding update-notes entry

## Validation

- confirmed the RotorHazard installation flow is unchanged from 4.4.0
- confirmed server API 49 and node API 36 are unchanged
- git diff --check